### PR TITLE
Bug fix: Use cl-map, not map

### DIFF
--- a/counsel-tramp.el
+++ b/counsel-tramp.el
@@ -130,7 +130,7 @@ Kill all remote buffers."
 				   (concat "/docker:" counsel-tramp-docker-user "@" (car info) ":/")
 				   hosts))))))
     (when (require 'vagrant-tramp nil t)
-      (cl-loop for box-name in (map 'list 'cadr (vagrant-tramp--completions))
+      (cl-loop for box-name in (cl-map 'list 'cadr (vagrant-tramp--completions))
 	       do (progn
 		    (push (concat "/vagrant:" box-name ":/") hosts)
 		    (push (concat "/vagrant:" box-name "|sudo:root@" box-name ":/") hosts))))


### PR DESCRIPTION
Fixes error: `counsel-tramp--candidates: Symbol's function definition is void: map`