### PR TITLE
Check for built-in docker functionality with tramp 

### DIFF
--- a/counsel-tramp.el
+++ b/counsel-tramp.el
@@ -25,6 +25,7 @@
 ;; counsel-tramp provides interfaces of Tramp
 ;; You can also use tramp with counsel interface as root
 ;; If you use it with docker-tramp, you can also use docker with counsel interface
+;; If you use Emacs version >= 29.0.60 then docker-tramp is no longer necessary as this functionality is built-in to Tramp.
 ;; If you use it with vagrant-tramp, you can also use vagrant with counsel interface
 
 ;;; Code:

--- a/counsel-tramp.el
+++ b/counsel-tramp.el
@@ -154,7 +154,7 @@ Kill all remote buffers."
 	      (push
 	       (concat "/" counsel-tramp-default-method ":" hostuser "@" hostname "#" port "|sudo:root@" hostname ":/")
 	       hosts))))))
-    (when (and (require 'docker-tramp nil t) (ignore-errors (apply #'process-lines "pgrep" (list "-f" "docker"))))
+    (when (and (or (version<= "29.0.60" emacs-version) (require 'docker-tramp nil t)) (ignore-errors (apply #'process-lines "pgrep" (list "-f" "docker"))))
       (cl-loop for line in (cdr (ignore-errors (apply #'process-lines "docker" (list "ps"))))
 	       for info = (reverse (split-string line "[[:space:]]+" t))
 	       collect (progn (push

--- a/counsel-tramp.el
+++ b/counsel-tramp.el
@@ -209,7 +209,7 @@ You can connect your server with tramp"
   (interactive)
   (unless (file-exists-p "~/.ssh/config")
     (error "There is no ~/.ssh/config"))
-  (when (require 'docker-tramp nil t)
+  (when (or (version<= "29.0.60" emacs-version) (require 'docker-tramp nil t))
     (unless (executable-find "docker")
       (error "'docker' is not installed")))
   (when (require 'vagrant-tramp nil t)


### PR DESCRIPTION
Small update to check the emacs version before performing any actions with counsel-tramp related to docker. You can now use the built-in tramp to connect to docker containers in Emacs version `29.0.60`.